### PR TITLE
Add maximum-scale property to meta tag

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -3,7 +3,7 @@
 	<head>
 
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no">
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
 	<link rel="preload" as="script" href="js/bundle.vendor.js">
 	<link rel="preload" as="script" href="js/bundle.js">


### PR DESCRIPTION
Fixes issue with Safari zooming in on input focus.

Before:
https://cl.ly/e0f0fe0295da

After:
https://cl.ly/2e4a043c87e8